### PR TITLE
feat: two-pass scope-aware transpilation

### DIFF
--- a/include/AST/Node.hpp
+++ b/include/AST/Node.hpp
@@ -3,9 +3,37 @@
 #include <memory>
 #include <vector>
 #include <sstream>
+#include <unordered_set>
 
 namespace Lexer::AST {
 class Parser;
+
+struct Scope {
+    Scope* parent = nullptr;
+    std::unordered_set<std::string> vars;
+    std::vector<std::string> order;
+
+    bool declare(const std::string& name) {
+        if (vars.count(name)) return false;
+        vars.insert(name);
+        order.push_back(name);
+        return true;
+    }
+
+    std::string emitVars() const {
+        if (order.empty()) return "";
+        std::string result;
+        for (size_t i = 0; i < order.size(); i++) {
+            if (i > 0) result += ", ";
+            result += order[i];
+        }
+        return result;
+    }
+};
+
+struct TranspileContext {
+    Scope* currentScope = nullptr;
+};
 
 class Node {
 public:
@@ -13,7 +41,7 @@ public:
 
     virtual ~Node() = default;
     virtual void print(size_t indent = 0) const = 0;
-    virtual std::ostringstream& transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent = 0) const = 0;
+    virtual std::ostringstream& transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent = 0) const = 0;
 };
 
 
@@ -43,7 +71,7 @@ public:
 public:\
     x() = default;\
     void print(size_t indent) const final;\
-    std::ostringstream& transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const final;\
+    std::ostringstream& transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const final;\
     static Expr::Ptr parse(Parser& parser); \
 };
 
@@ -51,7 +79,7 @@ public:\
 public: \
     explicit x(__VA_ARGS__) : ctor {};\
     void print(size_t indent) const final;\
-    std::ostringstream& transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const final;\
+    std::ostringstream& transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const final;\
     static Expr::Ptr parse(Parser& parser, Expr::Ptr expr = nullptr);\
     DECL(__VA_ARGS__)\
 };
@@ -60,7 +88,7 @@ public: \
 public:\
     x() = default;\
     void print(size_t indent) const final;\
-    std::ostringstream& transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const final;\
+    std::ostringstream& transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const final;\
     static Stmt::Ptr parse(Parser& parser);\
 };
 
@@ -68,7 +96,7 @@ public:\
 public: \
     explicit x(__VA_ARGS__) : ctor {};\
     void print(size_t indent) const final;\
-    std::ostringstream& transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const final;\
+    std::ostringstream& transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const final;\
     static Stmt::Ptr parse(Parser& parser);\
     DECL(__VA_ARGS__)\
 };

--- a/src/AST/AST_transpile.cpp
+++ b/src/AST/AST_transpile.cpp
@@ -4,38 +4,38 @@
 
 namespace Lexer::AST {
 
-std::ostringstream& Number::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Number::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(" << value << ")";
     return os;
 }
 
-std::ostringstream& String::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& String::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(u\"" << value << "\")";
     return os;
 }
 
-std::ostringstream& Boolean::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Boolean::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(" << value << ")";
     return os;
 }
 
-std::ostringstream& Null::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Null::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(nullptr)";
     return os;
 }
 
-std::ostringstream& Undefined::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Undefined::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any()";
     return os;
 }
 
-std::ostringstream& This::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& This::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "thisArg";
     return os;
 }
 
 
-std::ostringstream& RegularExpression::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& RegularExpression::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     std::string pattern = value;
     std::string flags;
     size_t lastSlash = pattern.rfind('/');
@@ -50,102 +50,102 @@ std::ostringstream& RegularExpression::transpile(std::ostringstream& os, std::os
 }
 
 
-std::ostringstream& Array::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Array::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(JS::InternalObject::create<JS::Array>(std::vector<JS::Any>{\n";
     for (size_t i = 0; i < elements.size(); ++i) {
         if (i > 0)
             os << ",\n";
         os << std::string(indent + 4, ' ');
-        elements[i]->transpile(os, vars, indent + 4);
+        elements[i]->transpile(os, ctx, indent + 4);
     }
     os << "\n" << std::string(indent, ' ') << "}))";
     return os;
 }
 
-std::ostringstream& Object::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Object::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(JS::InternalObject::create<JS::Object>(std::unordered_map<std::u16string, JS::Any>{\n";
     for (size_t i = 0; i < properties.size(); ++i) {
         if (i > 0)
             os << ",\n";
         os << std::string(indent + 4, ' ');
         os << "{u\"" << properties[i].first << "\", ";
-        properties[i].second->transpile(os, vars, indent + 4);
+        properties[i].second->transpile(os, ctx, indent + 4);
         os << "}";
     }
     os << "\n" << std::string(indent, ' ') << "}))";
     return os;
 }
 
-std::ostringstream& Identifier::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Identifier::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << name;
     return os;
 }
 
-std::ostringstream& Grouped::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& Grouped::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "(";
-    expression->transpile(os, vars, indent);
+    expression->transpile(os, ctx, indent);
     os << ")";
     return os;
 }
 
-std::ostringstream& BinaryExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& BinaryExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     static const std::unordered_map<std::string, std::string> opMap = {
         {"===", "strictEq"}, {"!==", "strictNeq"}, {">>>", "URightShift"},
     };
-    left->transpile(os, vars, indent);
+    left->transpile(os, ctx, indent);
     os << " " << (opMap.contains(op) ? opMap.at(op) : op) << " ";
-    right->transpile(os, vars, indent);
+    right->transpile(os, ctx, indent);
     return os;
 }
 
-std::ostringstream& AssignementExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& AssignementExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     static const std::unordered_map<std::string, std::string> opMap = {
         {">>>=", "URightShift"}, {"<<=", "<<"}, {">>=", ">>"},
         {"+=", "+"}, {"-=", "-"}, {"*=", "*"}, {"/=", "/"}, {"%=", "%"},
         {"&=", "&"}, {"|=", "|"}, {"^=", "^"},
     };
     // treat as binary expression for compound assignments like a += b => a = a + b
-    left->transpile(os, vars, indent);
+    left->transpile(os, ctx, indent);
     os << " = ";
     if (opMap.contains(op)) {
-        left->transpile(os, vars, indent);
+        left->transpile(os, ctx, indent);
         os << " " << opMap.at(op) << " ";
     }
-    right->transpile(os, vars, indent);
+    right->transpile(os, ctx, indent);
     return os;
 }
 
-std::ostringstream& UnaryExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& UnaryExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     static const std::unordered_map<std::string, std::string> opMap = {
         {"typeof", "typeOf"}, {"delete", "del"}, {"void", "Void"},
     };
     if (op == "void")
         os << "(";
     os << (opMap.contains(op) ? opMap.at(op) : op);
-    expr->transpile(os, vars, indent);
+    expr->transpile(os, ctx, indent);
     if (op == "void")
         os << ")";
     return os;
 }
 
-std::ostringstream& PostfixExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
-    expr->transpile(os, vars, indent);
+std::ostringstream& PostfixExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
+    expr->transpile(os, ctx, indent);
     os << op;
     return os;
 }
 
-std::ostringstream& ConditionalExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
-    condition->transpile(os, vars, indent);
+std::ostringstream& ConditionalExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
+    condition->transpile(os, ctx, indent);
     os << " ? ";
-    trueExpr->transpile(os, vars, indent);
+    trueExpr->transpile(os, ctx, indent);
     os << " : ";
-    falseExpr->transpile(os, vars, indent);
+    falseExpr->transpile(os, ctx, indent);
     return os;
 }
 
-std::ostringstream& NewExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& NewExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "NEW(";
-    callee->transpile(os, vars, indent);
+    callee->transpile(os, ctx, indent);
     if (arguments.empty()) {
         os << ")";
         return os;
@@ -154,43 +154,51 @@ std::ostringstream& NewExpr::transpile(std::ostringstream& os, std::ostringstrea
     for (size_t i = 0; i < arguments.size(); ++i) {
         if (i > 0)
             os << ", ";
-        arguments[i]->transpile(os, vars, indent);
+        arguments[i]->transpile(os, ctx, indent);
     }
     os << ")";
     return os;
 }
 
-std::ostringstream& MemberExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
-    object->transpile(os, vars, indent);
+std::ostringstream& MemberExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
+    object->transpile(os, ctx, indent);
     if (computed) {
         std::string identifier = dynamic_cast<Identifier*>(property.get()) ? dynamic_cast<Identifier*>(property.get())->name : "";
         os << "[u\"" << identifier << "\"]";
     } else {
         os << "[";
-        property->transpile(os, vars, indent);
+        property->transpile(os, ctx, indent);
         os << "]";
     }
     return os;
 }
 
-std::ostringstream& CallExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
-    callee->transpile(os, vars, indent);
+std::ostringstream& CallExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
+    callee->transpile(os, ctx, indent);
     os << "(";
     for (size_t i = 0; i < arguments.size(); ++i) {
         if (i > 0)
             os << ", ";
-        arguments[i]->transpile(os, vars, indent);
+        arguments[i]->transpile(os, ctx, indent);
     }
     os << ")";
     return os;
 }
 
-std::ostringstream& FunctionExpr::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& FunctionExpr::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "JS::Any(JS::InternalObject::create<JS::Function>([&](const JS::Any &thisArg, const JS::Any &arguments) -> JS::Any {\n";
     for (size_t i = 0; i < params.size(); i++) {
         os << std::string(indent + 4, ' ') << "JS::Any " << params[i] << " = arguments[u\"" << i << "\"];\n";
     }
-    body->transpile(os, vars, indent + 4);
+    Scope funcScope;
+    funcScope.parent = ctx.currentScope;
+    std::ostringstream bodyOs;
+    TranspileContext bodyCtx{&funcScope};
+    body->transpile(bodyOs, bodyCtx, indent + 4);
+    if (!funcScope.order.empty()) {
+        os << std::string(indent + 4, ' ') << "JS::Any " << funcScope.emitVars() << ";\n";
+    }
+    os << bodyOs.str();
     os << std::string(indent + 4, ' ') << "return JS::Any();\n";
     os << std::string(indent, ' ') << "}, " << params.size() << ", u\"" << (name.empty() ? "anonymous" : name) << "\"))";
     return os;
@@ -198,42 +206,41 @@ std::ostringstream& FunctionExpr::transpile(std::ostringstream& os, std::ostring
 
 // Statement transpile implementations
 
-std::ostringstream& BlockStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& BlockStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "\n" << std::string(indent, ' ') << "{\n";
     for (const auto& stmt : body) {
-        stmt->transpile(os, vars, indent + 4);
+        stmt->transpile(os, ctx, indent + 4);
     }
     os << std::string(indent, ' ') << "}\n";
     return os;
 }
 
-std::ostringstream& VarDecl::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
-    vars << name << ", ";
+std::ostringstream& VarDecl::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
+    ctx.currentScope->declare(name);
     if (init) {
         os << std::string(indent, ' ') << name << " = ";
-        init->transpile(os, vars, indent);
+        init->transpile(os, ctx, indent);
         os << ";\n";
-        return os;
     }
     return os;
 }
 
-std::ostringstream& ExpressionStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& ExpressionStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ');
-    expression->transpile(os, vars, indent);
+    expression->transpile(os, ctx, indent);
     os << ";\n";
     return os;
 }
 
-std::ostringstream& IfStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& IfStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     // check if else before
     if (os.str().rfind("else") != os.str().size() - 5) {
         os << std::string(indent, ' ');
     }
     os << "if (";
-    test->transpile(os, vars, indent);
+    test->transpile(os, ctx, indent);
     os << ") ";
-    consequent->transpile(os, vars, indent);
+    consequent->transpile(os, ctx, indent);
     if (alternate) {
         // remove newline before else for better formatting with >>
         if (os.str().back() == '\n') {
@@ -243,32 +250,32 @@ std::ostringstream& IfStmt::transpile(std::ostringstream& os, std::ostringstream
             os << str;
         }
         os << " else ";
-        alternate->transpile(os, vars, indent);
+        alternate->transpile(os, ctx, indent);
     }
     return os;
 }
 
-std::ostringstream& WhileStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& WhileStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "while (";
-    test->transpile(os, vars, 0);
+    test->transpile(os, ctx, 0);
     os << ") ";
-    body->transpile(os, vars, indent);
+    body->transpile(os, ctx, indent);
     return os;
 }
 
-std::ostringstream& DoWhileStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& DoWhileStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "do ";
-    body->transpile(os, vars, indent);
+    body->transpile(os, ctx, indent);
     os << std::string(indent, ' ') << "while (";
-    test->transpile(os, vars, 0);
+    test->transpile(os, ctx, 0);
     os << ");\n";
     return os;
 }
 
-std::ostringstream& ForStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& ForStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "for (";
     if (init) {
-        init->transpile(os, vars, 0);
+        init->transpile(os, ctx, 0);
     } else {
         os << "; ";
     }
@@ -279,18 +286,18 @@ std::ostringstream& ForStmt::transpile(std::ostringstream& os, std::ostringstrea
         os << str << " ";
     }
     if (test) {
-        test->transpile(os, vars, indent);
+        test->transpile(os, ctx, indent);
     }
     os << "; ";
     if (update) {
-        update->transpile(os, vars, indent);
+        update->transpile(os, ctx, indent);
     }
     os << ") ";
-    body->transpile(os, vars, indent);
+    body->transpile(os, ctx, indent);
     return os;
 }
 
-std::ostringstream& ForInStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& ForInStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     static size_t varCounter = 0;
     // make something like that
     /*
@@ -312,7 +319,7 @@ std::ostringstream& ForInStmt::transpile(std::ostringstream& os, std::ostringstr
     os << std::string(indent, ' ') << "{\n";
     os << std::string(indent + 4, ' ') << "// for-in loop transpiled by JS_CMP not optimize for now\n";
     os << std::string(indent + 4, ' ') << "JS::Any " << keysVar << " = JS::Object::keys(Object, JS::Arguments::CreateArgumentsObject(std::vector<JS::Any>{";
-    right->transpile(os, vars, indent + 4);
+    right->transpile(os, ctx, indent + 4);
     os << "}));\n";
     os << std::string(indent + 4, ' ') << "size_t " << keysLenVar << " = static_cast<size_t>(std::get<double>(" << keysVar << "[u\"length\"].getValue()));\n";
     os << std::string(indent + 4, ' ') << "for (size_t " << indexVar << " = 0; " << indexVar << " < " << keysLenVar << "; " << indexVar << "++) ";
@@ -321,7 +328,7 @@ std::ostringstream& ForInStmt::transpile(std::ostringstream& os, std::ostringstr
     if ((varDecl = dynamic_cast<VarDecl*>(left.get()))) {
         os << std::string(indent + 8, ' ') << "JS::Any " << varDecl->name;
     } else {
-        left->transpile(os, vars, indent + 8);
+        left->transpile(os, ctx, indent + 8);
         // check if there is ;\n at the end and remove it
         std::string str = os.str();
         if (str.size() >= 2 && str.substr(str.size() - 2) == ";\n") {
@@ -331,13 +338,13 @@ std::ostringstream& ForInStmt::transpile(std::ostringstream& os, std::ostringstr
         }
     }
     os << " = " << keysVar << "[std::to_string(" << indexVar << ")];\n";
-    body->transpile(os, vars, indent + 8);
+    body->transpile(os, ctx, indent + 8);
     os << std::string(indent + 4, ' ') << "}\n";
     os << std::string(indent, ' ') << "}\n";
     return os;
 }
 
-std::ostringstream& ContinueStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& ContinueStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "continue";
     if (!label.empty()) {
         os << " /* label: " << label << " JS_CMP does not support labeled continue for now */";
@@ -346,7 +353,7 @@ std::ostringstream& ContinueStmt::transpile(std::ostringstream& os, std::ostring
     return os;
 }
 
-std::ostringstream& BreakStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& BreakStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "break";
     if (!label.empty()) {
         os << " /* label: " << label << " JS_CMP does not support labeled break for now */";
@@ -355,54 +362,54 @@ std::ostringstream& BreakStmt::transpile(std::ostringstream& os, std::ostringstr
     return os;
 }
 
-std::ostringstream& ReturnStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& ReturnStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "return";
     if (argument) {
         os << " ";
-        argument->transpile(os, vars, indent);
+        argument->transpile(os, ctx, indent);
     }
     os << ";\n";
     return os;
 }
 
-std::ostringstream& WithStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& WithStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     throw std::runtime_error("with statement is not supported in transpilation and should be already caught during parsing.");
 }
 
-std::ostringstream& SwitchStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& SwitchStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     throw std::runtime_error("switch statement is not supported in transpilation for now - use if-else instead.");
 }
 
-std::ostringstream& SwitchCaseStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& SwitchCaseStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     throw std::runtime_error("switch case statement is not supported in transpilation for now - use if-else instead.");
 }
 
-std::ostringstream& LabeledStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& LabeledStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << label << ":\n";
     os << std::string(indent, ' ');
-    body->transpile(os, vars, indent);
+    body->transpile(os, ctx, indent);
     return os;
 }
 
-std::ostringstream& DebuggerStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& DebuggerStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << "/* debugger statement not supported - no-op */\n";
     return os;
 }
 
-std::ostringstream& EmptyStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& EmptyStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     return os;
 }
 
-std::ostringstream& ThrowStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& ThrowStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "throw ";
-    argument->transpile(os, vars, indent);
+    argument->transpile(os, ctx, indent);
     os << ";\n";
     return os;
 }
 
-std::ostringstream& TryStmt::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
+std::ostringstream& TryStmt::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
     os << std::string(indent, ' ') << "try ";
-    block->transpile(os, vars, indent);
+    block->transpile(os, ctx, indent);
     if (handler) {
         os << std::string(indent, ' ') << " catch (";
         if (!param.empty()) {
@@ -411,22 +418,30 @@ std::ostringstream& TryStmt::transpile(std::ostringstream& os, std::ostringstrea
             os << "...";
         }
         os << ") ";
-        handler->transpile(os, vars, indent);
+        handler->transpile(os, ctx, indent);
     }
     if (finalizer) {
         os << " /* finally not directly supported - using scope guard pattern */\n";
-        finalizer->transpile(os, vars, indent);
+        finalizer->transpile(os, ctx, indent);
     }
     return os;
 }
 
-std::ostringstream& FunctionDecl::transpile(std::ostringstream& os, std::ostringstream& vars, size_t indent) const {
-    vars << name << ", ";
+std::ostringstream& FunctionDecl::transpile(std::ostringstream& os, TranspileContext& ctx, size_t indent) const {
+    ctx.currentScope->declare(name);
     os << std::string(indent, ' ') << name << " = JS::Any(JS::InternalObject::create<JS::Function>([&](const JS::Any &thisArg, const JS::Any &arguments) -> JS::Any {\n";
     for (size_t i = 0; i < params.size(); i++) {
         os << std::string(indent + 4, ' ') << "JS::Any " << params[i] << " = arguments[u\"" << i << "\"];\n";
     }
-    body->transpile(os, vars, indent + 4);
+    Scope funcScope;
+    funcScope.parent = ctx.currentScope;
+    std::ostringstream bodyOs;
+    TranspileContext bodyCtx{&funcScope};
+    body->transpile(bodyOs, bodyCtx, indent + 4);
+    if (!funcScope.order.empty()) {
+        os << std::string(indent + 4, ' ') << "JS::Any " << funcScope.emitVars() << ";\n";
+    }
+    os << bodyOs.str();
     os << std::string(indent + 4, ' ') << "return JS::Any();\n";
     os << std::string(indent, ' ') << "}, " << params.size() << ", u\"" << (name.empty() ? "anonymous" : name) << "\"));\n";
     return os;

--- a/src/Optimization/Optimizer.cpp
+++ b/src/Optimization/Optimizer.cpp
@@ -21,15 +21,15 @@ void Optimizer::optimize(flag_t flags) {
 
 std::string Optimizer::transpile() const {
     std::ostringstream os;
-    std::ostringstream vars;
+    AST::Scope globalScope;
+    AST::TranspileContext ctx{&globalScope};
+
     for (const auto& stmt : ast) {
-        stmt->transpile(os, vars, 4);
+        stmt->transpile(os, ctx, 4);
     }
+
     std::stringstream main;
-    std::string varStr = vars.str();
-    if (!varStr.empty()) {
-        varStr = varStr.substr(0, varStr.size() - 2);
-    }
+    std::string varStr = globalScope.emitVars();
 
     main << "#include \"types/JsAny.hpp\"\n"
         << "#include \"global/global.hpp\"\n"


### PR DESCRIPTION
# Lexer Pull Request

## Overview

Replaced the flat `std::ostringstream& vars` parameter in the transpiler with a proper scope tree to fix duplicate variable declarations and function-local variable scope leaks.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [X] Performance improvement
- [ ] Documentation update

## Checklist

- [X] My code adheres to project style guidelines.
- [ ] I have tested changes on Linux and macOS.
- [ ] Tests have been added or updated as needed.
- [ ] Documentation is updated to reflect changes.
- [ ] All CI/CD checks pass with this pull request.

## Testing

Tested via the parent JS-CMP project on Windows 10 (MinGW-w64). All JS test cases produce correct C++ output: no duplicate `JS::Any` declarations, function-local variables stay inside function scopes.


### Example Testcases

1. Redeclaration:
  ```js
  // js test code

  var i = 1;
  console.log("Initial i:", i);
  
  var i = 5; // redeclaration in the same scope
  console.log("After redeclaration i:", i);
  
  i = 10; // assignment
  console.log("After assignment i:", i);
  ```
  ```cpp
  // cpp transpired code

  #include "types/JsAny.hpp"
  #include "global/global.hpp"
  #include "types/objects/Types.hpp"
  #include "customOperators/CustomOperators.hpp"
  
  int main() {
      JS::Any i;
      i = JS::Any(1);
      console[u"log"](JS::Any(u"Initial i:"), i);
      i = JS::Any(5);
      console[u"log"](JS::Any(u"After redeclaration i:"), i);
      i = JS::Any(10);
      console[u"log"](JS::Any(u"After assignment i:"), i);
      return 0;
  }
  ```

2. Scoping:
  ```js
  // js test code

  funct js test codeion factorial(n) {
      var result = 1;
      var i;
  
      for (i = 2; i <= n; i++) {
          result *= i;
      }
  
      return result;
  }

  console.log("Factorial of 5 =", factorial(5));
  ```
  ```cpp
  // cpp transpired code

  #include "types/JsAny.hpp"
  #include "global/global.hpp"
  #include "types/objects/Types.hpp"
  #include "customOperators/CustomOperators.hpp"
  
  int main() {
      JS::Any factorial;
      factorial = JS::Any(JS::InternalObject::create<JS::Function>([&](const JS::Any &thisArg, const JS::Any &arguments) -> JS::Any {
          JS::Any n = arguments[u"0"];
          JS::Any result, i;
  
          {
              result = JS::Any(1);
              for (i = JS::Any(2); i <= n; i++) 
              {
                  result = result * i;
              }
              return result;
          }
          return JS::Any();
      }, 1, u"factorial"));
      console[u"log"](JS::Any(u"Factorial of 5 ="), factorial(JS::Any(5)));
      return 0;
  }
  ```

## Additional Notes

Three files changed:
- **`include/AST/Node.hpp`**: Added `Scope` struct (set-based dedup + order vector) and `TranspileContext` struct (holds `Scope*`). Changed `transpile()` signature in base class and all 4 macros.
- **`src/AST/AST_transpile.cpp`**: All 40 methods updated. `VarDecl` calls `Scope::declare()` instead of appending to a flat string stream. `FunctionDecl`/`FunctionExpr` create child scopes with temp-buffer body walk to emit local vars before body code.
- **`src/Optimization/Optimizer.cpp`**: Replaced `std::ostringstream vars` with root `Scope` + `TranspileContext`.

The signature change is unavoidable but mechanical — 37 nodes just rename the parameter. No runtime library changes needed.